### PR TITLE
Start docker cadastre after postgis

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,5 +13,7 @@ services:
     build:
       context: .
     restart: always
+    depends_on:
+      - "postgis"
     ports:
       - 4567:4567


### PR DESCRIPTION
We need to start cadastre after postgis, otherwise the website cannot serve tiles.